### PR TITLE
refactor: 이미지 슬라이더 재사용 가능하게 state 추가

### DIFF
--- a/src/components/race-list/index.tsx
+++ b/src/components/race-list/index.tsx
@@ -1,27 +1,33 @@
 import ImageSlider from '@components/image-slider/inedx';
 import { raceType } from '@typings/race';
-import { RaceListDummy } from 'dummy';
-import React from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 import RaceItem from './race-item';
-import { NoResult, CustomButton, Wrapper } from './race-list.style';
+import { NoResult, Wrapper } from './race-list.style';
 
-const RaceList = () => {
-  const isData = true;
-  const RaceList: Array<raceType> = RaceListDummy;
+interface Props {
+  data: Array<raceType>;
+  height: number;
+  now?: number;
+  setNow?: Dispatch<SetStateAction<number>>;
+  styleType?: 'main' | 'register' | 'profile'; 
+  itemWidth?:number;
+}
+
+const RaceList = ({ data, height, now, setNow, styleType='main' }: Props) => {
+  
   return (
     <Wrapper>
-      {RaceList.length !== 0 ? (
-        <ImageSlider SliderHeight={115}>
-          {RaceList.map((v, i) => (
-            <RaceItem key={i} item={v} />
+      {data.length !== 0 ? (
+        <ImageSlider SliderHeight={height}>
+          {data.map((v, i) => (
+            <div key={i} onClick={()=>setNow && setNow(v.raceId)}>
+              <RaceItem  item={v} isActive={now === v.raceId} styleType={styleType} />
+            </div>
           ))}
         </ImageSlider>
       ) : (
         <NoResult>참여 중인 레이스가 없습니다.</NoResult>
       )}
-      <CustomButton>
-        {RaceList.length === 0 ? <span>레이스 참여 하러가기</span> : <span>이 레이스에 운동 인증하기</span>}
-      </CustomButton>
     </Wrapper>
   );
 };

--- a/src/components/race-list/race-item.tsx
+++ b/src/components/race-list/race-item.tsx
@@ -1,11 +1,41 @@
 import { raceType } from '@typings/race';
 import React, { useState } from 'react';
-import { ItemWrapper } from './race-list.style';
+import { ItemWrapper, ProfileWrapper, RegisterWrapper } from './race-list.style';
 
-const RaceItem = ({item}:{item:raceType}) => {
+const RaceItem = ({
+  item,
+  isActive,
+  styleType,
+}: {
+  item: raceType;
+  isActive?: boolean;
+  styleType: 'main' | 'register' | 'profile';
+}) => {
+  if (styleType === 'register') {
+    return (
+      <RegisterWrapper active={isActive}>
+        <p>D-{item.Dday}</p>
+        <h3>{item.raceName}</h3>
+        <div>#{item.hashTag}</div>
+      </RegisterWrapper>
+    );
+  }else if(styleType === 'profile'){
+    return (
+      <ProfileWrapper>
+        <p>D-{item.Dday}</p>
+        <h3>{item.raceName}</h3>
+        <div>#{item.hashTag}</div>
+      </ProfileWrapper>
+    )
+  }
+
   return (
-    <ItemWrapper >{item.raceName}</ItemWrapper>
-  )
-}
+    <ItemWrapper active={isActive}>
+      <p>D-{item.Dday}</p>
+      <h3>{item.raceName}</h3>
+      <div>#{item.hashTag}</div>
+    </ItemWrapper>
+  );
+};
 
 export default RaceItem;

--- a/src/components/race-list/race-list.style.ts
+++ b/src/components/race-list/race-list.style.ts
@@ -1,34 +1,117 @@
 import styled from 'styled-components';
 
-
 export const Wrapper = styled.div`
-  position:relative;
+  position: relative;
 `;
 
 export const NoResult = styled.div`
-  font-weight:500;
-  color:var(--gray-04);
-  text-align:center;
-  width:100%;
-  height:115px;
-  line-height:115px;
-`
+  font-weight: 500;
+  color: var(--gray-04);
+  text-align: center;
+  width: 100%;
+  height: 115px;
+  line-height: 115px;
+`;
 
-export const ItemWrapper = styled.div`
-  padding: 12px;
-  width:130px;
-  height:100px;
-  background-color:var(--primary-purple);
-  border-radius:20px;
-  
-`
+export const ItemWrapper = styled.div<{ active?: boolean }>`
+  display: inline-block;
+  padding: 8px 12px 12px 12px;
+  width: 138px;
+  background-color: ${props => (props.active ? 'var(--primary-purple)' : 'var(--gray-02)')};
+  border-radius: 20px;
+  & p {
+    font-size: 12px;
+    font-weight: 500;
+    color: ${props => (props.active ? 'rgba(255, 255, 255, 0.8)' : '#fff')};
+    text-align: right;
+    padding-bottom: 13px;
+  }
+  & h3 {
+    font-weight: 700;
+    font-size: 18px;
+    color: white;
+    padding-bottom: 6px;
+  }
+  & div {
+    display: inline-block;
+    padding: 4px 8px;
+    background-color: ${props => (props.active ? 'var(--primary-mint)' : '#fff')};
+    border-radius: 43px;
+    color: ${props => (props.active ? 'var(--primary-purple)' : 'var(--gray-02)')};
+    font-size: 14px;
+    font-weight: 500;
+  }
+`;
 
 export const CustomButton = styled.button`
-  border-radius:20px;
-  background-color:var(--purple-sub01);
-  color:var(--primary-purple);
-  width:100%;
+  border-radius: 20px;
+  background-color: var(--purple-sub01);
+  color: var(--primary-purple);
+  width: 100%;
   padding: 18px 0px;
-  font-weight:500;
-  font-size:16px;
-`
+  font-weight: 500;
+  font-size: 16px;
+  margin-top:16px;
+`;
+
+
+export const RegisterWrapper = styled.div<{ active?: boolean }>`
+  display: inline-block;
+  padding: 8px 12px 12px 12px;
+  width: 138px;
+  background-color: #fff;
+  border: 2px solid ${props=> props.active ? 'var(--primary-purple)': 'var(--gray-02)'};
+  border-radius: 20px;
+  & p {
+    font-size: 12px;
+    font-weight: 500;
+    color: ${props => props.active ? 'var(--primary-purple)': 'var(--gray-02)'};
+    text-align: right;
+    padding-bottom: 13px;
+  }
+  & h3 {
+    font-weight: 700;
+    font-size: 18px;
+    color: ${props => props.active ? 'var(--primary-purple)': 'var(--gray-02)'};
+    padding-bottom: 6px;
+  }
+  & div {
+    display: inline-block;
+    padding: 4px 8px;
+    background-color: ${props => props.active ? 'var(--primary-purple)': 'var(--gray-02)'};
+    border-radius: 43px;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 500;
+  }
+`;
+
+export const ProfileWrapper = styled.div`
+  display: inline-block;
+  padding: 8px 12px 12px 12px;
+  width: 178px;
+  background-color:var(--purple-sub01);
+  border-radius: 20px;
+  & p {
+    font-size: 16px;
+    font-weight: 500;
+    color: #AC8EFF;
+    text-align: right;
+    padding-bottom: 13px;
+  }
+  & h3 {
+    font-weight: 700;
+    font-size: 20px;
+    color: var(--primary-purple);
+    padding-bottom: 6px;
+  }
+  & div {
+    display: inline-block;
+    padding: 4px 8px;
+    background-color: #AC8EFF;
+    border-radius: 43px;
+    color: white;
+    font-size: 14px;
+    font-weight: 500;
+  }
+`;

--- a/src/components/user-carousel/carousel-item.tsx
+++ b/src/components/user-carousel/carousel-item.tsx
@@ -2,13 +2,13 @@ import ProfileImage from '@components/profile-imgae';
 import React from 'react';
 import { ItemWrapper } from './carousel.style';
 
-const CarouselItem = ({nickname, url}:{ nickname:string, url:string|null}) => {
+const CarouselItem = ({ nickname, url, isActive }: { nickname: string; url: string | null; isActive: boolean }) => {
   return (
-    <ItemWrapper>
-      <ProfileImage url={url} alt='user_profile'/>
+    <ItemWrapper active={isActive}>
+      <ProfileImage url={url} alt='user_profile' />
       <div>{nickname}</div>
     </ItemWrapper>
-  )
-}
+  );
+};
 
 export default CarouselItem;

--- a/src/components/user-carousel/carousel.style.ts
+++ b/src/components/user-carousel/carousel.style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Wrapper = styled.section`
   padding: 30px 0px 0px 0px;
@@ -22,7 +22,13 @@ export const SwiperWrapper = styled.div`
   }
 `;
 
-export const ItemWrapper = styled.div`
+export const ItemWrapper = styled.div<{active:boolean}>`
+  ${(props)=> props.active && css`
+    background-color:white;
+    box-shadow: 3px 3px 15px rgb(0 0 0 / 10%);
+  `}
+  border-radius:20px;
+  padding: 8px 0px;
   & img {
     width: 50px;
     height: 50px;

--- a/src/components/user-carousel/index.tsx
+++ b/src/components/user-carousel/index.tsx
@@ -1,12 +1,16 @@
-import React, { useState } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { SwiperWrapper, Wrapper } from './carousel.style';
-import { userDummy } from 'dummy';
 import CarouselItem from './carousel-item';
 import { ReactComponent as RightArrow } from '@assets/icons/right-arrow.svg';
 import { ReactComponent as LeftArrow } from '@assets/icons/left-arrow.svg';
-const UserCarousel = () => {
-  const userData = userDummy;
+import { User } from '@typings/user';
+interface Props {
+  data:Array<Partial<User>>;
+  now?:number;
+  setNow?:Dispatch<SetStateAction<number>>;
+}
+const UserCarousel = ({data, now ,setNow}:Props) => {
   const [swiper, setSwiper] = useState<any>();
   const [reachingEnd, setReachingEnd] = useState<boolean>(false);
   const [reachingFirst, setReachingFirst] = useState<boolean>(true);
@@ -27,9 +31,9 @@ const UserCarousel = () => {
             e.isBeginning ? setReachingFirst(true) : setReachingFirst(false);
           }}
         >
-          {userData.map(v => (
-            <SwiperSlide key={v.id}>
-              <CarouselItem nickname={v.nickname} url={v.imageUrl} />
+          {data.map(v => (
+            <SwiperSlide key={v.id} onClick={()=>setNow && setNow(v.id as number)}>
+              <CarouselItem nickname={v.nick_name as string} url={v.profile_img as string | null} isActive={now === v.id as number} />
             </SwiperSlide>
           ))}
         </Swiper>

--- a/src/dummy.tsx
+++ b/src/dummy.tsx
@@ -2,56 +2,56 @@ import { raceType } from '@typings/race';
 import { User } from '@typings/user';
 import WorkoutSample from '@assets/images/workout-sample.png';
 
-export const userDummy = [
-  {
-    id: 0,
-    nickname: '나',
-    imageUrl: null,
-  },
+export const userDummy:Array<Partial<User>> = [
   {
     id: 1,
-    nickname: 'user1',
-    imageUrl: null,
+    nick_name: '나',
+    profile_img: null,
   },
   {
     id: 2,
-    nickname: 'user2',
-    imageUrl: null,
+    nick_name: 'user1',
+    profile_img: null,
   },
   {
     id: 3,
-    nickname: 'user3',
-    imageUrl: null,
+    nick_name: 'user2',
+    profile_img: null,
   },
   {
     id: 4,
-    nickname: 'user4',
-    imageUrl: null,
+    nick_name: 'user3',
+    profile_img: null,
   },
   {
     id: 5,
-    nickname: 'user5',
-    imageUrl: null,
+    nick_name: 'user4',
+    profile_img: null,
   },
   {
     id: 6,
-    nickname: 'user6',
-    imageUrl: null,
+    nick_name: 'user5',
+    profile_img: null,
   },
   {
     id: 7,
-    nickname: 'user7',
-    imageUrl: null,
+    nick_name: 'user6',
+    profile_img: null,
   },
   {
     id: 8,
-    nickname: 'user8',
-    imageUrl: null,
+    nick_name: 'user7',
+    profile_img: null,
   },
   {
     id: 9,
-    nickname: 'user9',
-    imageUrl: null,
+    nick_name: 'user8',
+    profile_img: null,
+  },
+  {
+    id: 10, 
+    nick_name: 'user9',
+    profile_img: null,
   },
 ];
 

--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -1,20 +1,40 @@
 import MainProfile from '@components/main-profile';
 import RaceList from '@components/race-list';
+import { CustomButton } from '@components/race-list/race-list.style';
 import UserCarousel from '@components/user-carousel';
-import WorkOutList from '@components/WorkoutList';
-import React from 'react';
+import WorkOutList from '@components/workoutList';
+import { raceType } from '@typings/race';
+import { MyInfo, RaceListDummy, userDummy } from 'dummy';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 const MainPage = () => {
+  /* 벡엔드에서 레이스 데이터 가져옴 */
+  const RaceData: Array<raceType> = RaceListDummy;
+  /* 벡엔드에서 user data 가져옴 */
+  const userData = userDummy;
+  /* 벡엔드에서 my-info 가져옴 */
+  const myInfo = MyInfo;
+
+  const [carouselSelected, setCarouselSelected] = useState(myInfo.id);
+  const [raceSelected, setRaceSelected] = useState(RaceData[0].raceId);
+
   return (
     <Wrapper>
       {/*MainProfile 에서는 MyProfile 정보만 필요 */}
       <MainProfile />
       {/*UserCarousel 에서는 selected Item 변경, MyProfileData(fllowerList) 필요*/}
-      <UserCarousel />
+      <UserCarousel data={userData} now={carouselSelected} setNow={setCarouselSelected} />
       {/*RaceList에서도 Selected Item 필요, 레이스 클릭 시 WorkOutList 바꿔서 보여 줌 */}
       <UserInfoWrapper>
-        <RaceList />
+        <div>now Slected Carousel Id: {carouselSelected}</div>
+        <RaceList data={RaceData} height={115} styleType='profile'/>
+        <RaceList data={RaceData} height={115} now={raceSelected} setNow={setRaceSelected} styleType='main'/>
+        <RaceList data={RaceData} height={115} now={raceSelected} setNow={setRaceSelected} styleType='register'/>
+        <CustomButton>
+          {RaceData.length === 0 ? <span>레이스 참여 하러가기</span> : <span>이 레이스에 운동 인증하기</span>}
+        </CustomButton>
+        <div>now Slected Race Id: {raceSelected}</div>
       </UserInfoWrapper>
     </Wrapper>
   );
@@ -24,19 +44,19 @@ const Wrapper = styled.div`
   width: 100%;
   height: 100%;
   background-color: #f9f9f9;
-  display:flex;
-  flex-direction:column;
+  display: flex;
+  flex-direction: column;
 `;
 
 const UserInfoWrapper = styled.section`
   margin-top: 12px;
   width: 100%;
-  flex:1;
+  flex: 1;
   background-color: #fff;
   box-shadow: 3px 3px 15px rgba(0, 0, 0, 0.1);
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
-  padding :20px;
+  padding: 20px;
 `;
 
 export default MainPage;

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -43,7 +43,7 @@ const ProfilePage = () => {
       <SlideSection>
         <h2>최근 운동 기록</h2>
         <h2>참영 중인 챌린지</h2>
-        <RaceList />
+        <RaceList data={RaceData} height={115} />
       </SlideSection>
     </PageWrapper>
   );


### PR DESCRIPTION
이미지 슬라이더 컴포넌트를 재사용 가능하게 state를 추가했습니다.
pages/main.tsx에 샘플 코드를 작성해 두었으니 보시면 사용법을 알 수 있습니다.
레이스 페이지에 사용되는 슬라이더는 css가 아예달라져야 해서 추후에 추가할 예정입니다.